### PR TITLE
Add openjdk8 to docker for OPSIN

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,4 +11,6 @@ ENV LC_ALL=C
 RUN python setup.py install && \
     (cd java/ && sh get_opsin.sh)
 
-CMD ["python", "-u", "/chem_bot/bin/run_twitter_client.py"]
+RUN apk add openjdk8
+
+CMD ["python", "-u", "bin/run_twitter_client.py"]


### PR DESCRIPTION
#14 これの原因ですが、dockerコンテナにopenjdkを入れてなかったからでした。

入れるようにDockerfileを修正しています。